### PR TITLE
refactor: Simplify Initialize to use hardcoded values

### DIFF
--- a/crates/alkanes-bonding-curve-token/Cargo.toml
+++ b/crates/alkanes-bonding-curve-token/Cargo.toml
@@ -21,3 +21,5 @@ protorune-support = { workspace = true } # Kept for now, build might show unused
 alkanes-std-factory-support = { workspace = true }
 ordinals = { workspace = true } # Kept for now, build might show unused
 anyhow = { workspace = true }
+
+# Removed bitcoin and hex dependencies as they are no longer needed by the simplified token logic

--- a/crates/alkanes-bonding-curve-token/src/lib.rs
+++ b/crates/alkanes-bonding-curve-token/src/lib.rs
@@ -25,11 +25,7 @@ impl AlkaneResponder for BondingCurveToken {}
 #[derive(MessageDispatch)]
 enum BondingCurveTokenMessage {
     #[opcode(0)]
-    Initialize {
-        name: String,
-        symbol: String,
-        total_supply: u128,
-    },
+    Initialize,
 
     #[opcode(99)]
     #[returns(String)]
@@ -52,14 +48,13 @@ impl BondingCurveToken {
     // Removed Owner, Balances, and Allowances storage methods
 
     // Refactored initialize
-    fn initialize(
-        &self,
-        name: String,
-        symbol: String,
-        total_supply: u128,
-    ) -> Result<CallResponse> {
+    fn initialize(&self) -> Result<CallResponse> {
         let context = self.context()?;
-        let response: CallResponse = CallResponse::forward(&context.incoming_alkanes.clone());
+        let mut response: CallResponse = CallResponse::forward(&context.incoming_alkanes.clone());
+
+        let name = "alkanes".to_string();
+        let symbol = "A".to_string();
+        let total_supply = 1_000_000_000_u128;
 
         // Set name and symbol using the MintableToken trait
         <Self as MintableToken>::set_name_and_symbol_str(self, name, symbol);
@@ -74,8 +69,6 @@ impl BondingCurveToken {
         };
         response.alkanes.0.push(minted_tokens_to_self);
 
-        // The response.alkanes is not modified here for initial minting.
-        // Tokens are tracked internally in the balances_map.
         Ok(response)
     }
 


### PR DESCRIPTION
This commit further simplifies the `alkanes-bonding-curve-token` for debugging purposes, to help isolate a runtime error ("expected end-of-file").

- The `Initialize` message in `BondingCurveTokenMessage` now takes no arguments.
- The `initialize` function in `impl BondingCurveToken` now:
    - Takes no arguments (only `&self`).
    - Uses hardcoded values for name ("alkanes"), symbol ("A"), and total_supply (1,000,000,000).
    - Continues to use `MintableToken` trait methods to set these attributes and mints the total supply to the contract's own address (`context.myself`), including this as an `AlkaneTransfer` in the response.

This change makes the contract's initialization interface minimal to test if the runtime error is related to parameter deserialization or a more fundamental issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The initialization process for the bonding curve token is now streamlined with fixed token details: name ("alkanes"), symbol ("A"), and a total supply of 1,000,000,000.

- **Refactor**
  - The token initialization no longer requires entering a name, symbol, or total supply—these are now set automatically.

- **Chores**
  - Unused dependencies have been removed to simplify the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->